### PR TITLE
Testes com mocha; Bundling para targets/browsers específicos;

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -3,10 +3,16 @@ module.exports = {
     [
       "@babel/preset-env", {
         "targets": {
-          "browsers": ["defaults"]
+          // "browsers": ["defaults"]
           // "browsers": ["last 2 versions", "safari >= 7"]
+          "ios": "9",
+          "ie": "11",
+          "chrome": "58"
         },
-        "modules": false
+        // we're using es6 on mocha (tests), so we can't use 'modules: false'
+        // @see https://github.com/babel/babel/issues/8477#issuecomment-413263400
+        // "modules": false,
+        "useBuiltIns": "usage"
       }
     ]
   ]

--- a/bin/mocha-watch
+++ b/bin/mocha-watch
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+
+//
+// IMPORTANT: it's a poc. It barely works.
+// It requires its dependencies to be installed
+// `yarn add --dev node-watch dependency-tree`
+//
+//
+// But it need further work
+// @see https://github.com/rhuelga/guard-mocha-node
+//
+// TODO list
+// - remove dependency-tree
+// - convention over configuration:
+//   - make a direct map between source files and test files
+//   - i.e. app/models/user.js => test/models/user.spec.js
+//
+//
+
+//
+// run with
+// ```bash
+// node bin/mocha-watch
+// ```
+//
+// @src https://github.com/mochajs/mocha/issues/2928#issuecomment-371658851
+
+
+'use strict'
+
+const watch = require('node-watch')
+const execSync = require('child_process').execSync
+const path = require('path')
+const fs = require('fs')
+const glob = require('glob')
+
+const WATCH_TIMEOUT = 100
+let changedFiles = []
+let timeout = null
+
+const APP_ROOT = path.resolve(path.join(__dirname, '..'))
+const TEST_DIRNAME = 'test' // change it to 'spec' if needed
+const TEST_DIR = path.join(APP_ROOT, TEST_DIRNAME)
+
+const testFileRE = /\.spec\.js$/
+const testFileSuffix = '.spec.js'
+const sourceFileRE = /\.js$/
+const sourceFileSuffix = '.js'
+
+
+function enqueue(name) {
+  if (timeout) clearTimeout(timeout)
+
+  changedFiles.push(name)
+
+  timeout = setTimeout(() => {
+    try {
+      // build test file list
+      let tests = []
+
+      for (let file of changedFiles) {
+        if (file.startsWith(TEST_DIR) && testFileRE.test(file)) {
+          tests.push(file)
+
+        } else {
+          // mapping of source-file => test-file.
+          // allows breaking files into multiple test files like:
+          // - app/routes/stakeholders.js
+          //   -> test/routes/stakeholders.index.spec.js
+          //   -> test/routes/stakeholders.create.spec.js
+          //   -> test/routes/stakeholders.destroy.spec.js
+          // - app/models/stakeholders.js
+          //   -> test/models/stakeholder.spec.js
+          //   -> test/models/stakeholder.validations.spec.js
+          // ----
+          let testFileGlobPath = file.replace(`${APP_ROOT}/`, '')
+            .replace(sourceFileSuffix, `*${testFileSuffix}`)
+
+          // `app/${dirs}` are directly mapped to test/${dirs}:
+          // -> app/routes/stakeholders.js -> test/routes/stakeholders*.spec.js
+          if (testFileGlobPath.startsWith('src/')) {
+            testFileGlobPath = testFileGlobPath.replace('src/', '')
+          }
+
+
+          testFileGlobPath = path.join(TEST_DIR, testFileGlobPath)
+
+          let matchingTestFiles = glob.sync(testFileGlobPath) // or empty array `[]`
+          tests = tests.concat(matchingTestFiles)
+        }
+      }
+
+
+      changedFiles = []
+
+      if (tests.length) {
+        let files = tests.join(' ')
+
+        // CHANGE YOUR COMMAND
+        // const command = `CI=true TS_NODE_FAST=true node mocha --exit "${files}" -P`
+        const command = `CI=true TS_NODE_FAST=true yarn run mocha --exit ${files}`
+        console.log('\n-- Running --\n')
+        console.log(command)
+
+        // redirecting stdio (stdout, stderr) to see output in terminal
+        // @see https://stackoverflow.com/a/31104898
+        // @see http://theantway.com/2016/12/capture-console-output-when-using-child_process-execsync-in-node-js/
+        execSync(command, { stdio: 'inherit' })
+      }
+    } catch (ex) {
+      console.error('[mocha-watch]', ex)
+    }
+  }, WATCH_TIMEOUT)
+}
+
+
+watch(
+  `${APP_ROOT}/src`, // i.e. src/models, src/routes, src/commands, ...
+  { recursive: true, filter: sourceFileRE },
+  (evt, name) => { enqueue(name) }
+)
+
+// watch(
+//   `${APP_ROOT}/lib`,
+//   { recursive: true, filter: sourceFileRE },
+//   (evt, name) => { enqueue(name) }
+// )
+
+
+watch(
+  `${APP_ROOT}/test`,
+  { recursive: true, filter: testFileRE },
+  (evt, name) => { enqueue(name) }
+)
+

--- a/dist/lodash-ext.cjs.js
+++ b/dist/lodash-ext.cjs.js
@@ -36,10 +36,9 @@ function _typeof(obj) {
 function deepCamelizeKeys(object) {
   var camelized = _.cloneDeep(object);
 
-  Object.keys(object).forEach(function (key) {
-    var value = object[key]; // checks that a value is a plain object or an array - for recursive key conversion
+  _.forOwn(object, function (value, key) {
+    // checks that a value is a plain object or an array - for recursive key conversion
     // recursively update keys of any values that are also objects
-
     if (_.isPlainObject(value) || _.isArray(value)) {
       value = deepCamelizeKeys(value);
       camelized[key] = value;
@@ -52,6 +51,7 @@ function deepCamelizeKeys(object) {
       delete camelized[key];
     }
   });
+
   return camelized;
 }
 
@@ -61,9 +61,27 @@ function camelizeKeys(value) {
   }
 
   return _.camelCase(value);
-} // module.exports = camelizeKeys
+}
 
-// const _ = require('lodash')
+var isBlank = function isBlank(value) {
+  switch (_typeof(value)) {
+    case 'string':
+      return !value.trim().length;
+
+    case 'boolean':
+      return false;
+
+    default:
+      // Rails like `blank?` - @https://github.com/lodash/lodash/issues/2261#issuecomment-211380044
+      return _.isEmpty(value) && !_.isNumber(value) || _.isNaN(value);
+  }
+}; // inspired by Rails/ActiveSupport Object#present?
+
+
+var isPresent = function isPresent(obj) {
+  return !isBlank(obj);
+};
+
 /**
  * Creates a new object, ignoring all keys/properties with "empty" values: null, undefined or empty objects or arrays.
  *
@@ -81,20 +99,29 @@ function camelizeKeys(value) {
 function deleteBlanks(object) {
   var result = _.cloneDeep(object);
 
-  Object.keys(result).forEach(function (key) {
-    var value = result[key];
-
+  _.forOwn(result, function (value, key) {
     if (_.isPlainObject(value) || _.isArray(value)) {
       result[key] = deleteBlanks(value);
-      if (_.isEmpty(result[key])) delete result[key];
-    } else if (value === null || value === undefined) {
+
+      if (_.isArray(result[key])) {
+        _.remove(result[key], isBlank);
+      }
+
+      if (isBlank(result[key])) {
+        delete result[key];
+      }
+    } else if (isBlank(value)) {
       delete result[key];
     }
   });
-  return result;
-} // module.exports = deleteBlanks
 
-// const _ = require('lodash')
+  if (_.isArray(result)) {
+    _.remove(result, isBlank);
+  }
+
+  return result;
+}
+
 /**
  * "Digs" the object searching for nested properties, ensuring it exists - or returning null.
  * Inspired by Ruby Object#dig.
@@ -114,38 +141,16 @@ function deleteBlanks(object) {
  */
 
 function dig(object) {
-  var dug = object;
-
-  for (var i = 0; i < (arguments.length <= 1 ? 0 : arguments.length - 1); i++) {
-    if (!_.isObjectLike(dug)) {
-      return dug;
-    }
-
-    var key = i + 1 < 1 || arguments.length <= i + 1 ? undefined : arguments[i + 1];
-    dug = dug[key];
+  for (var _len = arguments.length, keys = new Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+    keys[_key - 1] = arguments[_key];
   }
 
-  return dug;
-} // module.exports = dig
+  // DEPRECATED
+  // use _.get() instead.
+  var path = _.join(keys, '.');
 
-var isBlank = function isBlank(value) {
-  switch (_typeof(value)) {
-    case 'string':
-      return !value.trim().length;
-
-    case 'boolean':
-      return false;
-
-    default:
-      // Rails like `blank?` - @https://github.com/lodash/lodash/issues/2261#issuecomment-211380044
-      return _.isEmpty(value) && !_.isNumber(value) || _.isNaN(value);
-  }
-}; // inspired by Rails/ActiveSupport Object#present?
-
-
-var isPresent = function isPresent(obj) {
-  return !isBlank(obj);
-}; // module.exports = { isBlank, isPresent }
+  return _.get(object, path);
+}
 
 /**
  * Creates a new object transforming all of its properties to snake_case format.
@@ -165,10 +170,9 @@ var isPresent = function isPresent(obj) {
 function deepSnakeizeKeys(object) {
   var snakeized = _.cloneDeep(object);
 
-  Object.keys(object).forEach(function (key) {
-    var value = object[key]; // checks that a value is a plain object or an array - for recursive key conversion
+  _.forOwn(object, function (value, key) {
+    // checks that a value is a plain object or an array - for recursive key conversion
     // recursively update keys of any values that are also objects
-
     if (_.isPlainObject(value) || _.isArray(value)) {
       value = deepSnakeizeKeys(value);
       snakeized[key] = value;
@@ -181,6 +185,7 @@ function deepSnakeizeKeys(object) {
       delete snakeized[key];
     }
   });
+
   return snakeized;
 }
 
@@ -190,10 +195,9 @@ function snakeizeKeys(value) {
   }
 
   return _.snakeCase(value);
-} // module.exports = snakeizeKeys
+}
 
-// const _ = require('lodash')
-var lodashExt = Object.assign({}, _, {
+var lodashExt = _.assign({}, _, {
   // functions to handle object properties/keys transformation
   camelizeKeys: camelizeKeys,
   snakeizeKeys: snakeizeKeys,
@@ -214,8 +218,6 @@ var lodashExt = Object.assign({}, _, {
   // merge:    _.merge,
   equals: _.isEqual,
   contains: _.isMatch
-}); // module.exports = lodashExt
-
-// const lodashExt = require('./lodash-ext')
+});
 
 module.exports = lodashExt;

--- a/examples/browser/server.js
+++ b/examples/browser/server.js
@@ -26,7 +26,7 @@ const mimeType = {
 };
 
 http.createServer(function (req, res) {
-  console.log(`${req.method} ${req.url}`);
+  console.info(`${req.method} ${req.url}`);
 
   // parse URL
   const parsedUrl = url.parse(req.url);
@@ -69,4 +69,4 @@ http.createServer(function (req, res) {
 
 }).listen(parseInt(port));
 
-console.log(`Server listening on port ${port}`);
+console.info(`Server listening on port ${port}`);

--- a/examples/node/script.js
+++ b/examples/node/script.js
@@ -5,4 +5,4 @@ const distDir = path.join(__dirname, '..', '..', 'dist')
 
 const _ = require(path.join(distDir, 'lodash-ext.cjs.js'))
 
-console.log('lodash-ext keys:', Object.keys(_))
+console.info('lodash-ext keys:', Object.keys(_).sort())

--- a/package.json
+++ b/package.json
@@ -6,11 +6,20 @@
   "module": "dist/lodash-ext.esm.js",
   "browser": "dist/lodash-ext.umd.js",
   "dependencies": {
+    "@babel/polyfill": "^7.2.5",
     "lodash": "^4.17.11"
   },
   "devDependencies": {
     "@babel/core": "^7.2.2",
     "@babel/preset-env": "^7.2.3",
+    "@babel/register": "^7.0.0",
+    "chai": "^4.2.0",
+    "chai-as-promised": "^7.1.1",
+    "chai-change": "^2.1.2",
+    "chai-datetime": "^1.5.0",
+    "chai-subset": "^1.6.0",
+    "mocha": "^5.2.0",
+    "node-watch": "^0.6.0",
     "rollup": "^1.0.0",
     "rollup-plugin-babel": "^4.2.0",
     "rollup-plugin-commonjs": "^9.2.0",
@@ -21,7 +30,11 @@
     "build": "rollup -c",
     "dev": "rollup -c -w",
     "pretest": "npm run build",
-    "test": "node test/test.js"
+    "test": "mocha --exit",
+    "test:all": "mocha --exit \"test/**/*.spec.js\"",
+    "test:watch": "node ./bin/mocha-watch",
+    "//test:watch": "mocha --watch \"test/**/*.spec.js\"",
+    "//test:watch2": "nodemon --config nodemon.test.json --exec 'mocha \"test/**/*.spec.js\" || true'"
   },
   "files": [
     "dist"

--- a/src/camelize-keys.js
+++ b/src/camelize-keys.js
@@ -1,4 +1,3 @@
-// const _ = require('lodash')
 import _ from 'lodash'
 
 /**
@@ -18,8 +17,7 @@ import _ from 'lodash'
 function deepCamelizeKeys(object) {
   let camelized = _.cloneDeep(object)
 
-  Object.keys(object).forEach((key) => {
-    let value = object[key]
+  _.forOwn(object, (value, key) => {
 
     // checks that a value is a plain object or an array - for recursive key conversion
     // recursively update keys of any values that are also objects
@@ -46,5 +44,4 @@ function camelizeKeys(value) {
 }
 
 
-// module.exports = camelizeKeys
 export default camelizeKeys

--- a/src/delete-blanks.js
+++ b/src/delete-blanks.js
@@ -1,5 +1,5 @@
-// const _ = require('lodash')
 import _ from 'lodash'
+import { isBlank } from './is-blank'
 
 /**
  * Creates a new object, ignoring all keys/properties with "empty" values: null, undefined or empty objects or arrays.
@@ -17,21 +17,29 @@ import _ from 'lodash'
 function deleteBlanks(object) {
   let result = _.cloneDeep(object)
 
-  Object.keys(result).forEach((key) => {
-    let value = result[key]
-
+  _.forOwn(result, (value, key) => {
     if (_.isPlainObject(value) || _.isArray(value)) {
       result[key] = deleteBlanks(value)
 
-      if (_.isEmpty(result[key])) delete result[key]
+      if (_.isArray(result[key])) {
+        _.remove(result[key], isBlank)
+      }
 
-    } else if (value === null || value === undefined) {
+      if (isBlank(result[key])) {
+        delete result[key]
+      }
+
+    } else if (isBlank(value)) {
       delete result[key]
     }
   })
 
+  if (_.isArray(result)) {
+    _.remove(result, isBlank)
+  }
+
   return result
 }
 
-// module.exports = deleteBlanks
+
 export default deleteBlanks

--- a/src/dig.js
+++ b/src/dig.js
@@ -1,4 +1,3 @@
-// const _ = require('lodash')
 import _ from 'lodash'
 
 /**
@@ -19,19 +18,12 @@ import _ from 'lodash'
  * @return {Object}           value of the nested properti, or `undefined` if it does not exist
  */
 function dig(object, ...keys) {
-  let dug = object
+  // DEPRECATED
+  // use _.get() instead.
 
-  for (let i = 0; i < keys.length; i++) {
-    if (!_.isObjectLike(dug)) {
-      return dug
-    }
-
-    const key = keys[i]
-    dug = dug[key]
-  }
-
-  return dug
+  let path = _.join(keys, '.')
+  return _.get(object, path)
 }
 
-// module.exports = dig
+
 export default dig

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
-// const lodashExt = require('./lodash-ext')
 import lodashExt from './lodash-ext'
 
-// module.exports = lodashExt
+
 export default lodashExt

--- a/src/is-blank.js
+++ b/src/is-blank.js
@@ -1,4 +1,3 @@
-// const _ = require('lodash')
 import _ from 'lodash'
 
 // inspired by Rails/ActiveSupport Object#blank?
@@ -17,7 +16,6 @@ const isPresent = function isPresent(obj) {
   return !isBlank(obj);
 }
 
-// module.exports = { isBlank, isPresent }
-// export { isBlank, isPresent }
+
 export default isBlank
 export { isBlank, isPresent }

--- a/src/lodash-ext.js
+++ b/src/lodash-ext.js
@@ -1,18 +1,12 @@
-// const _ = require('lodash')
 import _ from 'lodash'
-// const camelizeKeys = require('./camelize-keys')
 import camelizeKeys from './camelize-keys'
-// const deleteBlanks = require('./delete-blanks')
 import deleteBlanks from './delete-blanks'
-// const dig = require('./dig')
 import dig from './dig'
-// const { isBlank, isPresent } = require('./is-blank')
 import { isBlank, isPresent } from './is-blank'
-// const snakeizeKeys = require('./snakeize-keys')
 import snakeizeKeys from './snakeize-keys'
 
 
-const lodashExt = Object.assign({}, _, {
+const lodashExt = _.assign({}, _, {
 
   // functions to handle object properties/keys transformation
   camelizeKeys,
@@ -40,5 +34,5 @@ const lodashExt = Object.assign({}, _, {
 
 })
 
-// module.exports = lodashExt
+
 export default lodashExt

--- a/src/snakeize-keys.js
+++ b/src/snakeize-keys.js
@@ -1,4 +1,3 @@
-// const _ = require('lodash')
 import _ from 'lodash'
 
 /**
@@ -18,8 +17,7 @@ import _ from 'lodash'
 function deepSnakeizeKeys(object) {
   let snakeized = _.cloneDeep(object)
 
-  Object.keys(object).forEach((key) => {
-    let value = object[key]
+  _.forOwn(object, (value, key) => {
 
     // checks that a value is a plain object or an array - for recursive key conversion
     // recursively update keys of any values that are also objects
@@ -45,5 +43,5 @@ function snakeizeKeys(value) {
   return _.snakeCase(value)
 }
 
-// module.exports = snakeizeKeys
+
 export default snakeizeKeys

--- a/test/camelize-keys.spec.js
+++ b/test/camelize-keys.spec.js
@@ -1,0 +1,56 @@
+// _ already global
+
+describe('_.camelizeKeys(object)', () => {
+
+  let object = {
+    key: 1,
+    "kebab-key": "2",
+    snake_key: 'three',
+    camelKey: 'cu4tro',
+    nested: {
+      key: 'nested.1',
+      'kebab-key': 'nested.2',
+      snake_key: 'nested.tree',
+      camelKey: 'neste.cu4tro'
+    }
+  }
+  let camelized = _.camelizeKeys(object)
+
+
+  describe('with kebab-case keys', () => {
+    it('camelizes keys', () => {
+      expect(camelized.kebabKey).to.equal(object['kebab-key'])
+      expect(_.has(camelized, 'kebab-key')).to.be.false
+    })
+
+    it('camelizes nested keys', () => {
+      expect(_.get(camelized, 'nested.kebabKey')).to.equal(_.get(object, 'nested.kebab-key'))
+      expect(_.has(camelized, 'nested.kebab-key')).to.be.false
+    })
+  })
+
+  describe('with snake_case keys', () => {
+    it('camelizes keys', () => {
+      expect(camelized.snakeKey).to.equal(object['snake_key'])
+      expect(_.has(camelized, 'snake_key')).to.be.false
+    })
+
+    it('camelizes nested keys', () => {
+      expect(_.get(camelized, 'nested.snakeKey')).to.equal(_.get(object, 'nested.snake_key'))
+      expect(_.has(camelized, 'nested.snake_key')).to.be.false
+    })
+  })
+
+  describe('with camelCase keys', () => {
+    it('does not change keys', () => {
+      expect(camelized.camelKey).to.equal(object['camelKey'])
+      expect(_.has(camelized, 'camelKey')).to.be.true
+    })
+
+    it('does not change nested keys', () => {
+      expect(_.get(camelized, 'nested.camelKey')).to.equal(_.get(object, 'nested.camelKey'))
+      expect(_.has(camelized, 'nested.camelKey')).to.be.true
+    })
+  })
+
+})

--- a/test/delete-blanks.spec.js
+++ b/test/delete-blanks.spec.js
@@ -1,0 +1,36 @@
+// _ already global
+
+describe('_.deleteBlanks(object)', () => {
+
+  it('deletes blank values from array', () => {
+    let array = ['', 0, [], 'string']
+    expect(_.deleteBlanks(array)).to.deep.equal([0, 'string'])
+  })
+
+  it('delete keys with blank values', () => {
+    let object = {
+      value1: "val1",
+      value2: undefined,
+      value3: null,
+      value4: {},
+      nested: {
+        value1: 0,
+        value2: false,
+        value3: [],
+        value4: '  ',
+      },
+      array: ['', 0, true]
+    }
+    let pruned = _.deleteBlanks(object)
+
+    expect(pruned).to.deep.equal({
+      value1: 'val1',
+      nested: {
+        value1: 0,
+        value2: false
+      },
+      array: [0, true]
+    })
+  })
+
+})

--- a/test/dig.spec.js
+++ b/test/dig.spec.js
@@ -1,0 +1,26 @@
+// _ already global
+
+describe('_.dig(object, keys...)', () => {
+  let family = {
+      parent: {
+        child: "It's me!"
+      }
+    }
+
+  it('digs for existing keys', () => {
+    expect(_.dig(family, 'parent')).to.deep.equal(family.parent)
+  })
+
+  it('digs for existing nested keys', () => {
+    expect(_.dig(family, 'parent', 'child')).to.deep.equal(family.parent.child)
+  })
+
+  it('digs for non existing nested keys', () => {
+    expect(_.dig(family, 'parent', 'child', 'grandchild')).to.be.undefined
+  })
+
+  it('digs fail-safely for non existing keys', () => {
+    expect(_.dig(family, 'grandparent', 'parent')).to.be.undefined
+  })
+
+})

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,0 +1,13 @@
+// This file is included in the test suite by the `--file` option in `./mocha.opts` file.
+// @see https://mochajs.org/#--file-file
+//      https://github.com/mochajs/mocha/issues/3094#issuecomment-375745630
+
+'use strict'
+
+// we can define "global hooks" here.
+
+// afterEach(async () => {
+//   // restore all sandbox stubs
+//   // @see https://sinonjs.org/releases/v6.3.4/sandbox/
+//   sinon.restore()
+// })

--- a/test/is-blank.spec.js
+++ b/test/is-blank.spec.js
@@ -1,0 +1,59 @@
+// _ already global
+
+describe('_.isBlank(val)', () => {
+
+  describe('blank values', () => {
+    it('considers empty string as blank', () => {
+      expect(_.isBlank('')).to.be.true
+    })
+
+    it('considers all blank spaces string as blank', () => {
+      expect(_.isBlank('   ')).to.be.true
+    })
+
+    it('considers null as blank', () => {
+      expect(_.isBlank(null)).to.be.true
+    })
+
+    it('considers undefined as blank', () => {
+      expect(_.isBlank(undefined)).to.be.true
+    })
+
+    it('considers empty array as blank', () => {
+      expect(_.isBlank([])).to.be.true
+    })
+
+    it('considers empty object as blank', () => {
+      expect(_.isBlank({})).to.be.true
+    })
+  })
+
+
+  describe('not blank values', () => {
+    it('considers non-empty string as not blank', () => {
+      let string = _.sample(['a', '0', 'asda', '    a '])
+      expect(_.isBlank(string)).to.be.false
+    })
+
+    it('considers true as not blank', () => {
+      expect(_.isBlank(true)).to.be.false
+    })
+
+    it('considers false as not blank', () => {
+      expect(_.isBlank(true)).to.be.false
+    })
+
+    it('considers 0 as not blank', () => {
+      expect(_.isBlank(0)).to.be.false
+    })
+
+    it('considers non-empty array as not blank', () => {
+      expect(_.isBlank([1])).to.be.false
+    })
+
+    it('considers non-empty object as not blank', () => {
+      expect(_.isBlank({ a: 1 })).to.be.false
+    })
+  })
+
+})

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,10 @@
+--colors
+--ui bdd
+--require @babel/register
+--require test/setup
+--file test/helper
+--recursive
+--reporter spec
+--check-leaks
+--full-trace
+--no-timeouts

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,43 @@
+'use strict'
+
+process.env.NODE_ENV = 'test'
+
+// Setting up the context with test libraries
+import chai from 'chai'
+import chaiAsPromised from 'chai-as-promised'
+import chaiChange from 'chai-change'
+import chaiDatetime from 'chai-datetime'
+// import chaiMoment from 'chai-moment'
+// import chaiHttp from 'chai-http'
+import chaiSubset from 'chai-subset'
+
+// import sinon from 'sinon'
+// import sinonChai from 'sinon-chai'
+
+// // debugging
+// import pry from 'pryjs'
+
+chai.use(chaiAsPromised)
+chai.use(chaiChange)
+chai.use(chaiDatetime)
+// chai.use(chaiHttp)
+// chai.use(chaiMoment)
+chai.use(chaiSubset)
+// chai.use(sinonChai)
+
+// exporting globally - to ease the use on specs/tests
+global.chai = chai
+global.expect = chai.expect
+// global.sinon = sinon
+
+// checkout http://sinonjs.org/releases/v4.4.2/sandbox/
+
+
+// // exporting pryjs
+// // to debug, call a `eval(pry.it)` anywhere on the code
+// global.pry = pry
+
+
+// exporting the lib globally
+import _ from '../src/index'
+global._ = _

--- a/test/snakeize-keys.spec.js
+++ b/test/snakeize-keys.spec.js
@@ -1,0 +1,56 @@
+// _ already global
+
+describe('_.snakeizeKeys(object)', () => {
+
+  let object = {
+    key: 1,
+    "kebab-key": "2",
+    snake_key: 'three',
+    camelKey: 'cu4tro',
+    nested: {
+      key: 'nested.1',
+      'kebab-key': 'nested.2',
+      snake_key: 'nested.tree',
+      camelKey: 'neste.cu4tro'
+    }
+  }
+  let snakeizes = _.snakeizeKeys(object)
+
+
+  describe('with kebab-case keys', () => {
+    it('snakeizes keys', () => {
+      expect(snakeizes.kebab_key).to.equal(object['kebab-key'])
+      expect(_.has(snakeizes, 'kebab-key')).to.be.false
+    })
+
+    it('snakeizes nested keys', () => {
+      expect(_.get(snakeizes, 'nested.kebab_key')).to.equal(_.get(object, 'nested.kebab-key'))
+      expect(_.has(snakeizes, 'nested.kebab-key')).to.be.false
+    })
+  })
+
+  describe('with snake_case keys', () => {
+    it('does not change keys', () => {
+      expect(snakeizes.snake_key).to.equal(object['snake_key'])
+      expect(_.has(snakeizes, 'snake_key')).to.be.true
+    })
+
+    it('does not change nested keys', () => {
+      expect(_.get(snakeizes, 'nested.snake_key')).to.equal(_.get(object, 'nested.snake_key'))
+      expect(_.has(snakeizes, 'nested.snake_key')).to.be.true
+    })
+  })
+
+  describe('with camelCase keys', () => {
+    it('snakeizes keys', () => {
+      expect(snakeizes.camel_key).to.equal(object['camelKey'])
+      expect(_.has(snakeizes, 'camelKey')).to.be.false
+    })
+
+    it('snakeizes nested keys', () => {
+      expect(_.get(snakeizes, 'nested.camel_key')).to.equal(_.get(object, 'nested.camelKey'))
+      expect(_.has(snakeizes, 'nested.camelKey')).to.be.false
+    })
+  })
+
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -448,6 +448,13 @@
     "@babel/helper-regex" "^7.0.0"
     regexpu-core "^4.1.3"
 
+"@babel/polyfill@^7.2.5":
+  version "7.2.5"
+  resolved "https://registry.yarnpkg.com/@babel/polyfill/-/polyfill-7.2.5.tgz#6c54b964f71ad27edddc567d065e57e87ed7fa7d"
+  dependencies:
+    core-js "^2.5.7"
+    regenerator-runtime "^0.12.0"
+
 "@babel/preset-env@^7.2.3":
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.3.1.tgz#389e8ca6b17ae67aaf9a2111665030be923515db"
@@ -495,6 +502,18 @@
     invariant "^2.2.2"
     js-levenshtein "^1.1.3"
     semver "^5.3.0"
+
+"@babel/register@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/register/-/register-7.0.0.tgz#fa634bae1bfa429f60615b754fc1f1d745edd827"
+  dependencies:
+    core-js "^2.5.7"
+    find-cache-dir "^1.0.0"
+    home-or-tmp "^3.0.0"
+    lodash "^4.17.10"
+    mkdirp "^0.5.1"
+    pirates "^4.0.0"
+    source-map-support "^0.5.9"
 
 "@babel/template@^7.1.0", "@babel/template@^7.1.2", "@babel/template@^7.2.2":
   version "7.2.2"
@@ -566,6 +585,21 @@ array-unique@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.2.1.tgz#a1d97ccafcbc2625cc70fadceb36a50c58b01a53"
 
+assertion-error@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
+
+balanced-match@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
+
+brace-expansion@^1.1.7:
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
+  dependencies:
+    balanced-match "^1.0.0"
+    concat-map "0.0.1"
+
 braces@^1.8.2:
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/braces/-/braces-1.8.5.tgz#ba77962e12dff969d6b76711e914b737857bf6a7"
@@ -574,6 +608,10 @@ braces@^1.8.2:
     preserve "^0.2.0"
     repeat-element "^1.1.2"
 
+browser-stdout@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
+
 browserslist@^4.3.4:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.4.1.tgz#42e828954b6b29a7a53e352277be429478a69062"
@@ -581,6 +619,10 @@ browserslist@^4.3.4:
     caniuse-lite "^1.0.30000929"
     electron-to-chromium "^1.3.103"
     node-releases "^1.1.3"
+
+buffer-from@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
 
 builtin-modules@^3.0.0:
   version "3.0.0"
@@ -594,6 +636,37 @@ caniuse-lite@^1.0.30000929:
   version "1.0.30000935"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000935.tgz#d1b59df00b46f4921bb84a8a34c1d172b346df59"
 
+chai-as-promised@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/chai-as-promised/-/chai-as-promised-7.1.1.tgz#08645d825deb8696ee61725dbf590c012eb00ca0"
+  dependencies:
+    check-error "^1.0.2"
+
+chai-change@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/chai-change/-/chai-change-2.1.2.tgz#1231cdf8bf5930eea1fab72b5cc4864e5bcae7f6"
+
+chai-datetime@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/chai-datetime/-/chai-datetime-1.5.0.tgz#3742f18b024c75b76a2b7eee291662324467596c"
+  dependencies:
+    chai ">1.9.0"
+
+chai-subset@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/chai-subset/-/chai-subset-1.6.0.tgz#a5d0ca14e329a79596ed70058b6646bd6988cfe9"
+
+chai@>1.9.0, chai@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-4.2.0.tgz#760aa72cf20e3795e84b12877ce0e83737aa29e5"
+  dependencies:
+    assertion-error "^1.1.0"
+    check-error "^1.0.2"
+    deep-eql "^3.0.1"
+    get-func-name "^2.0.0"
+    pathval "^1.1.0"
+    type-detect "^4.0.5"
+
 chalk@^2.0.0:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -601,6 +674,10 @@ chalk@^2.0.0:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
+
+check-error@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
 
 cli-table3@^0.5.0:
   version "0.5.1"
@@ -637,11 +714,27 @@ colors@^1.1.2:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.3.3.tgz#39e005d546afe01e01f9c4ca8fa50f686a01205d"
 
+commander@2.15.1:
+  version "2.15.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
+
+commondir@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
+
+concat-map@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+
 convert-source-map@^1.1.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.6.0.tgz#51b537a8c43e0f04dec1993bffcdd504e758ac20"
   dependencies:
     safe-buffer "~5.1.1"
+
+core-js@^2.5.7:
+  version "2.6.4"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.4.tgz#b8897c062c4d769dd30a0ac5c73976c47f92ea0d"
 
 cross-spawn@^6.0.0:
   version "6.0.5"
@@ -653,6 +746,12 @@ cross-spawn@^6.0.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
+debug@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  dependencies:
+    ms "2.0.0"
+
 debug@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
@@ -662,6 +761,16 @@ debug@^4.1.0:
 decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
+
+deep-eql@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-3.0.1.tgz#dfc9404400ad1c8fe023e7da1df1c147c4b444df"
+  dependencies:
+    type-detect "^4.0.0"
+
+diff@3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
 
 electron-to-chromium@^1.3.103:
   version "1.3.113"
@@ -673,7 +782,7 @@ end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
-escape-string-regexp@^1.0.5:
+escape-string-regexp@1.0.5, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
@@ -729,6 +838,20 @@ fill-range@^2.1.0:
     repeat-element "^1.1.2"
     repeat-string "^1.5.2"
 
+find-cache-dir@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-1.0.0.tgz#9288e3e9e3cc3748717d39eade17cf71fc30ee6f"
+  dependencies:
+    commondir "^1.0.1"
+    make-dir "^1.0.0"
+    pkg-dir "^2.0.0"
+
+find-up@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
+  dependencies:
+    locate-path "^2.0.0"
+
 find-up@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
@@ -745,9 +868,17 @@ for-own@^0.1.4:
   dependencies:
     for-in "^1.0.1"
 
+fs.realpath@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+
 get-caller-file@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
+
+get-func-name@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
 
 get-stream@^4.0.0:
   version "4.1.0"
@@ -768,13 +899,47 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
+glob@7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 globals@^11.1.0:
   version "11.10.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.10.0.tgz#1e09776dffda5e01816b3bb4077c8b59c24eaa50"
 
+growl@1.10.5:
+  version "1.10.5"
+  resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
+
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+
+he@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
+
+home-or-tmp@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-3.0.0.tgz#57a8fe24cf33cdd524860a15821ddc25c86671fb"
+
+inflight@^1.0.4:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
+  dependencies:
+    once "^1.3.0"
+    wrappy "1"
+
+inherits@2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
 invariant@^2.2.2:
   version "2.2.4"
@@ -902,6 +1067,13 @@ lcid@^2.0.0:
   dependencies:
     invert-kv "^2.0.0"
 
+locate-path@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
+  dependencies:
+    p-locate "^2.0.0"
+    path-exists "^3.0.0"
+
 locate-path@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
@@ -924,6 +1096,12 @@ magic-string@^0.25.1:
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.2.tgz#139c3a729515ec55e96e69e82a11fe890a293ad9"
   dependencies:
     sourcemap-codec "^1.4.4"
+
+make-dir@^1.0.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.3.0.tgz#79c1033b80515bd6d24ec9933e860ca75ee27f0c"
+  dependencies:
+    pify "^3.0.0"
 
 map-age-cleaner@^0.1.1:
   version "0.1.3"
@@ -965,9 +1143,45 @@ mimic-fn@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
 
+minimatch@3.0.4, minimatch@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
+  dependencies:
+    brace-expansion "^1.1.7"
+
+minimist@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
+
 minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
+
+mkdirp@0.5.1, mkdirp@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
+  dependencies:
+    minimist "0.0.8"
+
+mocha@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-5.2.0.tgz#6d8ae508f59167f940f2b5b3c4a612ae50c90ae6"
+  dependencies:
+    browser-stdout "1.3.1"
+    commander "2.15.1"
+    debug "3.1.0"
+    diff "3.5.0"
+    escape-string-regexp "1.0.5"
+    glob "7.1.2"
+    growl "1.10.5"
+    he "1.1.1"
+    minimatch "3.0.4"
+    mkdirp "0.5.1"
+    supports-color "5.4.0"
+
+ms@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
 ms@^2.1.1:
   version "2.1.1"
@@ -977,11 +1191,19 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
 
+node-modules-regexp@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
+
 node-releases@^1.1.3:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.7.tgz#b09a10394d0ed8f7778f72bb861dde68b146303b"
   dependencies:
     semver "^5.3.0"
+
+node-watch@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/node-watch/-/node-watch-0.6.0.tgz#ab0703b60cd270783698e57a428faa0010ed8fd0"
 
 normalize-path@^2.0.1:
   version "2.1.1"
@@ -1010,7 +1232,7 @@ object.omit@^2.0.0:
     for-own "^0.1.4"
     is-extendable "^0.1.1"
 
-once@^1.3.1, once@^1.4.0:
+once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   dependencies:
@@ -1036,17 +1258,33 @@ p-is-promise@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-2.0.0.tgz#7554e3d572109a87e1f3f53f6a7d85d1b194f4c5"
 
+p-limit@^1.1.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.3.0.tgz#b86bd5f0c25690911c7590fcbfc2010d54b3ccb8"
+  dependencies:
+    p-try "^1.0.0"
+
 p-limit@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.1.0.tgz#1d5a0d20fb12707c758a655f6bbc4386b5930d68"
   dependencies:
     p-try "^2.0.0"
 
+p-locate@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
+  dependencies:
+    p-limit "^1.1.0"
+
 p-locate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
   dependencies:
     p-limit "^2.0.0"
+
+p-try@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
 
 p-try@^2.0.0:
   version "2.0.0"
@@ -1065,6 +1303,10 @@ path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
 
+path-is-absolute@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
+
 path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
@@ -1072,6 +1314,26 @@ path-key@^2.0.0, path-key@^2.0.1:
 path-parse@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
+
+pathval@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
+
+pify@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
+
+pirates@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.0.tgz#850b18781b4ac6ec58a43c9ed9ec5fe6796addbd"
+  dependencies:
+    node-modules-regexp "^1.0.0"
+
+pkg-dir@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-2.0.0.tgz#f6d5d1109e19d63edf428e0bd57e12777615334b"
+  dependencies:
+    find-up "^2.1.0"
 
 preserve@^0.2.0:
   version "0.2.0"
@@ -1105,6 +1367,10 @@ regenerate-unicode-properties@^7.0.0:
 regenerate@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.0.tgz#4a856ec4b56e4077c557589cae85e7a4c8869a11"
+
+regenerator-runtime@^0.12.0:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
 
 regenerator-transform@^0.13.3:
   version "0.13.3"
@@ -1238,9 +1504,20 @@ signal-exit@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
+source-map-support@^0.5.9:
+  version "0.5.10"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.10.tgz#2214080bc9d51832511ee2bab96e3c2f9353120c"
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
 source-map@^0.5.0:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+
+source-map@^0.6.0:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
 sourcemap-codec@^1.4.4:
   version "1.4.4"
@@ -1277,6 +1554,12 @@ strip-eof@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
 
+supports-color@5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
+  dependencies:
+    has-flag "^3.0.0"
+
 supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
@@ -1290,6 +1573,10 @@ to-fast-properties@^2.0.0:
 trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
+
+type-detect@^4.0.0, type-detect@^4.0.5:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
- limpando um pouco o código
- deixando apenas sintaxe de módulos ES6 (Rollup)
- algumas dependências de apoio para o TDD funcionar legal como mocha
  - código de testes em ES6 (modules)
  - `yarn run test:watch` e vá ajustando o código
- alguns ajustes finos em métodos de extensão do lodash
  - trocando _builtins_ (`Object.assign`, `Object.keys`) por métodos lodash, evitando problemas com browsers mais antigos sem aumentar o tamanho do _bundle_
  - `deleteBlanks`
  - `isBlank` com mais casos de borda cobertos